### PR TITLE
chore(circleci): modify config to prevent failing build with gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
       - build:
           filters:
             branches:
-              only: gh-pages
+              only: aws
       - deploy_s3:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,10 @@ workflows:
                 - aws
   build-deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              only: gh-pages
       - deploy_s3:
           requires:
             - build


### PR DESCRIPTION
### What does this PR do?

This PR modifies the config file for circle-cli to only allow the `build` job to run on the `aws` branch.

### Background info

**Validated Config file using CircleCi cli**
![Screenshot from 2019-06-28 11-00-07](https://user-images.githubusercontent.com/49660567/60362060-c91f6c00-9994-11e9-807b-e1aee384cfe5.png)

We need to see if this will fix the issue for sure once this is merged into develop.

@brockfanning, please review as well. Thanks.

### Issue this PR is related to?

Issue #47 