### PR TITLE
feat(database): provide new database url to support https 

### DIFF
--- a/_config_prod.yml
+++ b/_config_prod.yml
@@ -11,15 +11,15 @@ environment: production
 #  ga_prod: 'paste UA code here'
 
 # Uncomment and configure to point to a different data source for production.
-remotedatabaseurl: "http://sdgdatabase.lamayor.org.s3-website-us-west-2.amazonaws.com"
+remotedatabaseurl: "https://d122m6ral8ka7l.cloudfront.net"
 jekyll_get_json:
   - data: meta
-    json: 'http://sdgdatabase.lamayor.org.s3-website-us-west-2.amazonaws.com/meta/all.json'
+    json: 'https://d122m6ral8ka7l.cloudfront.net/meta/all.json'
   - data: headlines
-    json: 'http://sdgdatabase.lamayor.org.s3-website-us-west-2.amazonaws.com/headline/all.json'
+    json: 'https://d122m6ral8ka7l.cloudfront.net/headline/all.json'
   - data: schema
-    json: 'http://sdgdatabase.lamayor.org.s3-website-us-west-2.amazonaws.com/meta/schema.json'
+    json: 'https://d122m6ral8ka7l.cloudfront.net/meta/schema.json'
   - data: reporting
-    json: 'http://sdgdatabase.lamayor.org.s3-website-us-west-2.amazonaws.com/stats/reporting.json'
+    json: 'https://d122m6ral8ka7l.cloudfront.net/stats/reporting.json'
   - data: translations
     json: 'https://open-sdg.github.io/sdg-translations/translations-0.5.1.json'


### PR DESCRIPTION
#### What does this PR do?

This PR allows us to use the cloudfront url for the database site hosted in the cloudfront distribution with the relating S3 bucket.

### Which issue relates to this PR?

This PR relates to #52 

### Any additional background info?

Once this is merged into `develop`, we should then merge `develop` into `aws` to reflect the changes on production.

close #52